### PR TITLE
Added to server and service model arguments to fix

### DIFF
--- a/coolipy/models/servers.py
+++ b/coolipy/models/servers.py
@@ -68,6 +68,7 @@ class ServerSettingsModel(CoolipyBaseModel):
     logdrain_newrelic_base_uri: Optional[str] = None
     logdrain_newrelic_license_key: Optional[str] = None
     wildcard_domain: Optional[str] = None
+    server_disk_usage_check_frequency: Optional[str] = None
 
 
 @dataclass
@@ -99,6 +100,7 @@ class ServerModel(CoolipyBaseModel):
     settings: Optional[ServerSettingsModel] = None
     is_reachable: Optional[bool] = None
     is_usable: Optional[bool] = None
+    is_coolify_host: Optional[bool] = None
 
     @override
     def _adjust_nested(self):

--- a/coolipy/models/service.py
+++ b/coolipy/models/service.py
@@ -46,6 +46,7 @@ class ServiceModel(CoolipyBaseModel):
     service_type: Optional[str] = None
     created_at: Optional[Union[str, datetime]] = None
     updated_at: Optional[Union[str, datetime]] = None
+    status: Optional[str] = None
 
     @override
     def _adjust_nested(self):


### PR DESCRIPTION
When trying to call `coolify.services.list()` I kept getting the errors indicating that the Coolify API has changed what it returns, so adding optional args to the service and server models fixes the issue. 