### PR TITLE
Added feature to omit the port number option on main client

### DIFF
--- a/coolipy/__init__.py
+++ b/coolipy/__init__.py
@@ -57,9 +57,10 @@ class Coolipy:
         coolify_api_key: str,
         coolify_endpoint: str,
         coolify_port: int = 8000,
+        omit_port: bool = False,
         http_protocol: str = "http",
     ):
-        self._coolify_url = f"{http_protocol}://{coolify_endpoint}:{coolify_port}"
+        self._coolify_url = f"{http_protocol}://{coolify_endpoint}" if omit_port else f"{http_protocol}://{coolify_endpoint}:{coolify_port}"
         self._api_base_endpoint = f"{self._coolify_url}{API_BASE_ENTRYPOINT}"
         self._coolify_api_key = coolify_api_key
         self._http = HttpService(


### PR DESCRIPTION
I added an issue about this, but it won't break any existing setups. It just adds an optional `omit_port` arg to the Coolipy client which if true, will just use the base URL without port number in the API route. 