### PR TITLE
added fields to github deploy pvt repo with key model

### DIFF
--- a/coolipy/models/applications.py
+++ b/coolipy/models/applications.py
@@ -16,8 +16,7 @@ class ServiceApplicationModel(CoolipyBaseModel):
     human_name: Optional[str] = None
     description: Optional[str] = None
     fqdn: Optional[str] = None
-    ports: Optional[List[str]] = None
-    exposes: Optional[str] = None
+    ports_exposes: Optional[str] = None
     status: Optional[str] = None
     service_id: Optional[int] = None
     exclude_from_status: Optional[bool] = None
@@ -185,6 +184,7 @@ class ApplicationPublicModelCreate:
     project_uuid: str
     server_uuid: str
     environment_name: str
+    environment_uuid: str
     ports_exposes: str
     instant_deploy: bool
 
@@ -208,6 +208,13 @@ class ApplicationPrivateGHModelCreate(ApplicationPublicModelCreate):
 @dataclass
 class ApplicationPublicPrivatePvtKeyGHModelCreate(ApplicationPublicModelCreate):
     private_key_uuid: str
+    project_uuid: str
+    server_uuid: str
+    environment_name: str
+    environment_uuid: str
+    git_repository: str
+    git_branch: str
+    build_pack: COOLIFY_BUILD_PACKS
 
 
 @dataclass


### PR DESCRIPTION
Added new fields to this model for bug fix. 
- I also propose changing the model's name to: `ApplicationPrivatePvtKeyGHModelCreate` from `ApplicationPublicPrivatePvtKeyGHModelCreate` since this seems to be geared more towards private repos based on the Coolify docs: https://coolify.io/docs/api-reference/api/operations/create-private-deploy-key-application